### PR TITLE
Upgrade to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Shipped version:** 0.16.0~ynh1
+**Shipped version:** 1.0.0~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Versión actual:** 0.16.0~ynh1
+**Versión actual:** 1.0.0~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Paketatutako bertsioa:** 0.16.0~ynh1
+**Paketatutako bertsioa:** 1.0.0~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Avec ce package, Faircamp régénérera automatiquement ([à l'aide de Systemd P
 En alternative à ce package, vous pouvez [installer Faircamp sur votre ordinateur](https://simonrepp.com/faircamp/manual/installation.html) et utiliser sa fonction rsync (avec les options `--deploy` ou `--deploy-destination`) pour envoyer le site web généré dans un dossier [My Webapp](https://apps.yunohost.org/app/my_webapp) sur votre serveur YunoHost.
 
 
-**Version incluse :** 0.16.0~ynh1
+**Version incluse :** 1.0.0~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Versión proporcionada:** 0.16.0~ynh1
+**Versión proporcionada:** 1.0.0~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Versi terkirim:** 0.16.0~ynh1
+**Versi terkirim:** 1.0.0~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Geleverde versie:** 0.16.0~ynh1
+**Geleverde versie:** 1.0.0~ynh1
 
 ## Schermafdrukken
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**Поставляемая версия:** 0.16.0~ynh1
+**Поставляемая версия:** 1.0.0~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -23,7 +23,7 @@ With this package, Faircamp will automatically regenerate ([using Systemd Path U
 Alternatively to this package, you can [install Faircamp on your computer](https://simonrepp.com/faircamp/manual/installation.html) and use its rsync feature (ith the `--deploy` or `--deploy-destination` options) to send the builded website to a [My Webapp](https://apps.yunohost.org/app/my_webapp) folder on your YunoHost server.
 
 
-**分发版本：** 0.16.0~ynh1
+**分发版本：** 1.0.0~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Faircamp"
 description.en = "A static site generator for audio artists and producers"
 description.fr = "Un générateur de site statique pour les artistes ou producteurices audio"
 
-version = "0.16.0~ynh1"
+version = "1.0.0~ynh1"
 
 maintainers = [ "OniriCorpe" ]
 
@@ -49,8 +49,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://simonrepp.com/faircamp/packages/faircamp_0.16.0-1+deb11_amd64.deb"
-    sha256 = "71bf5ad993c65181e16ba129bbda6aa52295022afd8a7a35f61836bb0922b580"
+    url = "https://simonrepp.com/faircamp/packages/faircamp_1.0.0-1+deb11_amd64.deb"
+    sha256 = "2688703a4d605b855f8808d7585a2c4c7fbaf3aa3290847c6f2c8d739f5f8188"
     in_subdir = false
     extract = false
     rename = "faircamp.deb"


### PR DESCRIPTION
Bonsoir!

I figured the 1.0.0 release would be a good occasion to get the yunohost package up-to-date with development again (hope you agree! :)). I saw that the yunohost-bot PRs are mostly failing, but I'd venture this is because they are auto-generated at a point when I'm tagging new releases, but where I haven't yet uploaded the debian packages (there is always a delay between these steps because the debian build processes rely on the tag to be present, so it can't be simultaneous currently).

In any case, if that theory is correct, this PR should actually work out in the CI, given I manually checked the integrity of the debian package link.

Thanks again for having launched the yunohost app - I can see it is being used quite a bit by artists out there!